### PR TITLE
Add S₀ Tuning (PEFT for hybrid recurrent-attention models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Enjoy it below!
 * Block-Biased Mamba for Long-Range Sequence Processing [[paper](https://arxiv.org/abs/2505.09022)] (2024.05.13)
 * Efficient Unstructured Pruning of Mamba State-Space Models for Resource-Constrained Environments [[paper](https://arxiv.org/abs/2505.08299)] (2025.05.13)
 
+* S₀ Tuning: Zero-Overhead Adaptation of Hybrid Recurrent-Attention Models [[paper](https://arxiv.org/abs/2604.01168)] [[code](https://github.com/JackYoung27/s0-tuning)] (2026.03)
+
 <span id="head7"></span>
 
 ###  Multi-Modal


### PR DESCRIPTION
S₀ tuning optimizes one state matrix per recurrent layer while freezing all model weights. On Qwen3.5-4B: +23.6 pp on HumanEval (p < 0.001, 10 seeds), +10.8 pp over LoRA, zero inference overhead. Tested on FalconH1-7B (Mamba-2).

Paper: https://arxiv.org/abs/2604.01168
Code: https://github.com/JackYoung27/s0-tuning